### PR TITLE
Add .gitmodules for missing submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "ds2024_30642_boar_daniel-ioan_assignment_1"]
+    path = ds2024_30642_boar_daniel-ioan_assignment_1
+    url = https://github.com/daniboar/ds2024_30642_boar_daniel-ioan_assignment_1.git
+[submodule "ds2024_30642_boar_daniel-ioan_assignment_2"]
+    path = ds2024_30642_boar_daniel-ioan_assignment_2
+    url = https://github.com/daniboar/ds2024_30642_boar_daniel-ioan_assignment_2.git
+[submodule "ds2024_30642_boar_daniel-ioan_assignment_3"]
+    path = ds2024_30642_boar_daniel-ioan_assignment_3
+    url = https://github.com/daniboar/ds2024_30642_boar_daniel-ioan_assignment_3.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# SD---Anul-4
+
+This repository uses git submodules for each assignment. The submodule
+configuration was missing, which made it difficult to clone the
+repository with all its code. The `.gitmodules` file now specifies the
+remote URLs for the submodules.
+
+To clone this repository with all assignments, run:
+
+```bash
+git clone --recurse-submodules <repo-url>
+```


### PR DESCRIPTION
## Summary
- add `.gitmodules` file so the repository's submodules can be cloned
- document how to clone the repository with submodules in a new README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684820a1aef88325b73d0330d5f93224